### PR TITLE
Replace annotations to allow for cleanup of annotations when removing them

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakIngress.java
@@ -25,7 +25,6 @@ import org.keycloak.operator.crds.v2alpha1.deployment.spec.IngressSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakStatusBuilder;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Optional;
 
@@ -57,7 +56,7 @@ public class KeycloakIngress extends OperatorManagedResource implements StatusUp
             if (resultIngress.getMetadata().getAnnotations() == null) {
                 resultIngress.getMetadata().setAnnotations(new HashMap<>());
             }
-            resultIngress.getMetadata().getAnnotations().putAll(defaultIngress.getMetadata().getAnnotations());
+            resultIngress.getMetadata().setAnnotations(defaultIngress.getMetadata().getAnnotations());
             resultIngress.setSpec(defaultIngress.getSpec());
             return Optional.of(resultIngress);
         }


### PR DESCRIPTION
I was testing to add and then remove an annotation, but the annotation was never removed from the ingress. This fixes it.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
