### PR TITLE
Update the docs to recommend a more recent version of Infinispan

### DIFF
--- a/docs/guides/high-availability/bblocks-multi-site.adoc
+++ b/docs/guides/high-availability/bblocks-multi-site.adoc
@@ -48,11 +48,6 @@ A deployment of {jdgserver_name} that leverages the {jdgserver_name}'s Cross-DC 
 *Not considered:* Direct interconnections between the Kubernetes clusters on the network layer.
 It might be considered in the future.
 
-[IMPORTANT]
-====
-Only {jdgserver_name} server versions 15.0.0 or greater are supported in multi-site deployments.
-====
-
 == {project_name}
 
 A clustered deployment of {project_name} in each site, connected to an external {jdgserver_name}.

--- a/docs/guides/high-availability/deploy-infinispan-kubernetes-crossdc.adoc
+++ b/docs/guides/high-availability/deploy-infinispan-kubernetes-crossdc.adoc
@@ -19,7 +19,7 @@ See the <@links.ha id="introduction" /> {section} for an overview.
 
 [IMPORTANT]
 ====
-Only {jdgserver_name} server versions 15.0.0 or greater are supported for external {jdgserver_name} deployments.
+Only versions based on Infinispan version ${properties["infinispan.version"]} or more recent patch releases are supported for external {jdgserver_name} deployments.
 ====
 
 == Architecture


### PR DESCRIPTION
Given the latest statement that we would need Infinispan 15.0.7, this updates the docs to point to the very latest patch release that is also used in the pom.xml

It might be something for the migration guide as well.

Closes #30934

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
